### PR TITLE
Adds in a native non-git related option (preparing for deprecation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ MAINTAINER SMART COSMOS Platform Core Team
 ENV CONFIG_FILE_URI 'https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster-config'
 ENV CONFIG_SERVER_LABEL 'master'
 ENV ENCRYPT_KEY ''
+ENV CONFIG_SEARCH_LOCATIONS ''
 
 # if you want to use a github token set the USERNAME to be the token
 # the password needs to be empty when using a token
 ENV SPRING_CLOUD_CONFIG_SERVER_GIT_USERNAME ''
 ENV SPRING_CLOUD_CONFIG_SERVER_GIT_PASSWORD ''
+ENV SPRING_PROFILES ''
 
 ADD target/smartcosmos-*.jar  /opt/smartcosmos/smartcosmos-config-server.jar
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ eureka:
     healthCheckUrlPath: /admin/health
 
 spring:
+  profiles.active: ${SPRING_PROFILES:git}
   cloud:
     config:
       server:
@@ -18,6 +19,8 @@ spring:
           uri: ${CONFIG_FILE_URI:https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster-config}
           basedir: target/config
           default-label: ${CONFIG_SERVER_LABEL:master}
+        native:
+          search-locations: ${CONFIG_SEARCH_LOCATIONS}
 
 info:
   project:


### PR DESCRIPTION
Allows you to provide config that is fully file-based rather than a git repository.  This will allow us to naturally deprecate config files and move them to config maps rather than fully remove the config server.

For an example of using it, see https://github.com/SMARTRACTECHNOLOGY/smartcosmos-devkit/tree/local-dev-friendly